### PR TITLE
Added ability to back up all vms

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It is necessery to install the oVirt Python-sdk.
 backup.py -c config.cfg -d
 
 	-c ... Path to the config file
-	-a ... prompts tool to backup all vms (wipes out vm list in config file)
+	-a ... prompts tool to backup all vms (replace vm list in config file)
 	-d ... Debug flag
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It is necessery to install the oVirt Python-sdk.
 backup.py -c config.cfg -d
 
 	-c ... Path to the config file
+	-a ... prompts tool to backup all vms (wipes out vm list in config file)
 	-d ... Debug flag
 
 ## Configuration

--- a/backup.py
+++ b/backup.py
@@ -10,7 +10,6 @@ from getopt import getopt, GetoptError
 from logger import Logger
 import vmlist
 
-all_vms = False
 """
 Main class to make the backups
 """
@@ -18,8 +17,9 @@ Main class to make the backups
 def main(argv):
     usage = "backup.py -c <config.cfg>"
     try:
-        opts, args = getopt(argv, "hc:d")
+        opts, args = getopt(argv, "hac:d")
         debug = False
+        all_vms = False
         if not opts:
             print usage
             sys.exit(1)
@@ -50,7 +50,7 @@ def main(argv):
     #add all vms to config file
     if all_vms:
         vms=api.vms.list(max=400)
-        vmlist.get_vm_list(vms)
+        vmlist.get_vm_list(vms,config_file)
 
     # Test if all VM names are valid
     for vm_from_list in config.get_vm_names():

--- a/backup.py
+++ b/backup.py
@@ -10,6 +10,7 @@ from getopt import getopt, GetoptError
 from logger import Logger
 import vmlist
 
+all_vms = False
 """
 Main class to make the backups
 """
@@ -30,7 +31,7 @@ def main(argv):
                 config_file = arg
             elif opt in ("-d"):
                 debug = True
-            elif opt in ("-a")
+            elif opt in ("-a"):
                 all_vms = True
     except GetoptError:
         print usage

--- a/backup.py
+++ b/backup.py
@@ -30,8 +30,8 @@ def main(argv):
                 config_file = arg
             elif opt in ("-d"):
                 debug = True
-	    elif opt in ("-a")
-		all_vms = True
+            elif opt in ("-a")
+                all_vms = True
     except GetoptError:
         print usage
         sys.exit(1)
@@ -48,8 +48,8 @@ def main(argv):
    
     #add all vms to config file
     if all_vms:
-    	vms=api.vms.list(max=400)
-	vmlist.get_vm_list(vms)
+        vms=api.vms.list(max=400)
+        vmlist.get_vm_list(vms)
 
     # Test if all VM names are valid
     for vm_from_list in config.get_vm_names():

--- a/backup.py
+++ b/backup.py
@@ -48,7 +48,7 @@ def main(argv):
    
     #add all vms to config file
     if all_vms:
-    	vms=api.vms.list(max=400) 
+    	vms=api.vms.list(max=400)
 	vmlist.get_vm_list(vms)
 
     # Test if all VM names are valid

--- a/backup.py
+++ b/backup.py
@@ -8,6 +8,7 @@ from vmtools import VMTools
 from config import Config
 from getopt import getopt, GetoptError
 from logger import Logger
+import vmlist
 
 """
 Main class to make the backups
@@ -29,6 +30,8 @@ def main(argv):
                 config_file = arg
             elif opt in ("-d"):
                 debug = True
+	    elif opt in ("-a")
+		all_vms = True
     except GetoptError:
         print usage
         sys.exit(1)
@@ -42,7 +45,12 @@ def main(argv):
     
     # Connect to server
     connect()
-    
+   
+    #add all vms to config file
+    if all_vms:
+    	vms=api.vms.list(max=400) 
+	vmlist.get_vm_list(vms)
+
     # Test if all VM names are valid
     for vm_from_list in config.get_vm_names():
         if not api.vms.get(vm_from_list):

--- a/vmlist.py
+++ b/vmlist.py
@@ -18,17 +18,15 @@ CAFILE="ca.crt"
 FILENAME="config.cfg"
 LOGFILENAME="list_setup.log"
 
-s1= '.'
-
 logging.basicConfig(level=logging.DEBUG,
                     format='%(asctime)s %(levelname)s %(message)s',
                     filename=LOGFILENAME,
                     filemode='w')
-def getObjInfo (objlist):
+def get_vm_list (vms):
 	vmstring="vm_names: ["
-	for obj in objlist[:-1]:
-		vmstring += '"'+obj.name+'"'+", " 
-	vmstring +='"'+objlist[-1].name+'"'+"]"
+	for vm in vms[:-1]:
+		vmstring += '"'+vm.name+'"'+", " 
+	vmstring +='"'+vms[-1].name+'"'+"]"
 	#print vmstring 
 	with open(FILENAME) as myfile:
 		out=open("config.tmp","w")
@@ -36,21 +34,21 @@ def getObjInfo (objlist):
 			out.write(re.sub("^vm_names.*$", vmstring, line))
 		out.close()
 		os.rename("config.tmp", FILENAME)
-if __name__ == "__main__":
-   	try:	
-        	api = API(url=APIURL,
-                      username=APIUSER,
-              	      password=APIPASS,
-                      ca_file=CAFILE)
-    		try: 
-			print ' \n I am logging in %s \n' % LOGFILENAME
-
-			getObjInfo(api.vms.list(max=400))
-
-    		except Exception as e:
-        		logging.debug('Error:\n%s' % str(e))
-		
-    		api.disconnect()
-	
-	except Exception as ex:
-   		logging.debug('Unexpected error: %s' % ex)
+#if __name__ == "__main__":
+#   	try:	
+#        	api = API(url=APIURL,
+#                      username=APIUSER,
+#              	      password=APIPASS,
+#                      ca_file=CAFILE)
+#    		try: 
+#			print ' \n I am logging in %s \n' % LOGFILENAME
+#
+#			getObjInfo(api.vms.list(max=400))
+#
+#    		except Exception as e:
+#        		logging.debug('Error:\n%s' % str(e))
+#		
+#    		api.disconnect()
+#	
+#	except Exception as ex:
+#   		logging.debug('Unexpected error: %s' % ex)

--- a/vmlist.py
+++ b/vmlist.py
@@ -1,0 +1,56 @@
+#! /usr/bin/python
+
+import sys
+import os
+import re
+from ovirtsdk.api import API 
+from ovirtsdk.xml import params
+from threading import Thread
+import time
+import logging
+
+#Configure
+ 
+APIURL="https://engine.example.com/api/"
+APIUSER="admin@internal"
+APIPASS="securepassword:)"
+CAFILE="ca.crt"
+FILENAME="config.cfg"
+LOGFILENAME="list_setup.log"
+
+s1= '.'
+
+logging.basicConfig(level=logging.DEBUG,
+                    format='%(asctime)s %(levelname)s %(message)s',
+                    filename=LOGFILENAME,
+                    filemode='w')
+def getObjInfo (objlist):
+	vmstring="vm_names: ["
+	for obj in objlist[:-1]:
+		vmstring += '"'+obj.name+'"'+", " 
+	vmstring +='"'+objlist[-1].name+'"'+"]"
+	#print vmstring 
+	with open(FILENAME) as myfile:
+		out=open("config.tmp","w")
+		for line in myfile:
+			out.write(re.sub("^vm_names.*$", vmstring, line))
+		out.close()
+		os.rename("config.tmp", FILENAME)
+if __name__ == "__main__":
+   	try:	
+        	api = API(url=APIURL,
+                      username=APIUSER,
+              	      password=APIPASS,
+                      ca_file=CAFILE)
+    		try: 
+			print ' \n I am logging in %s \n' % LOGFILENAME
+
+			getObjInfo(api.vms.list(max=400))
+
+    		except Exception as e:
+        		logging.debug('Error:\n%s' % str(e))
+		
+    		api.disconnect()
+	
+	except Exception as ex:
+   		logging.debug('Unexpected error: %s' % ex)

--- a/vmlist.py
+++ b/vmlist.py
@@ -3,55 +3,29 @@
 import sys
 import os
 import re
-#from ovirtsdk.api import API 
-#from ovirtsdk.xml import params
-#from threading import Thread
 import time
 import logging
 
 #Configure
  
-#APIURL="https://engine.example.com/api/"
-#APIUSER="admin@internal"
-#APIPASS="securepassword:)"
-#CAFILE="ca.crt"
-#FILENAME="config.cfg"
-LOGFILENAME="list_setup.log"
+LOGconfig_file="list_setup.log"
 
 logging.basicConfig(level=logging.DEBUG,
                     format='%(asctime)s %(levelname)s %(message)s',
-                    filename=LOGFILENAME,
+                    filename=LOGconfig_file,
                     filemode='w')
-def get_vm_list (vms):
+def get_vm_list (vms,config_file):
 	try:
 		vmstring="vm_names: ["
 		for vm in vms[:-1]:
 			vmstring += '"'+vm.name+'"'+", " 
 		vmstring +='"'+vms[-1].name+'"'+"]"
 		#print vmstring 
-		with open(FILENAME) as myfile:
+		with open(config_file) as myfile:
 			out=open("config.tmp","w")
 			for line in myfile:
 				out.write(re.sub("^vm_names.*$", vmstring, line))
 			out.close()
-			os.rename("config.tmp", FILENAME)
+			os.rename("config.tmp", config_file)
 	except Exception as ex:
                logging.debug('Unexpected error: %s' % ex)
-#if __name__ == "__main__":
-#   	try:	
-#        	api = API(url=APIURL,
-#                      username=APIUSER,
-#              	      password=APIPASS,
-#                      ca_file=CAFILE)
-#    		try: 
-#			print ' \n I am logging in %s \n' % LOGFILENAME
-#
-#			getObjInfo(api.vms.list(max=400))
-#
-#    		except Exception as e:
-#        		logging.debug('Error:\n%s' % str(e))
-#		
-#    		api.disconnect()
-#	
-#	except Exception as ex:
-#   		logging.debug('Unexpected error: %s' % ex)

--- a/vmlist.py
+++ b/vmlist.py
@@ -4,16 +4,17 @@ import sys
 import os
 import re
 import time
-import logging
+#import logging
+from logger import Logger
 
 #Configure
  
-LOGconfig_file="list_setup.log"
+#LOGconfig_file="list_setup.log"
 
-logging.basicConfig(level=logging.DEBUG,
-                    format='%(asctime)s %(levelname)s %(message)s',
-                    filename=LOGconfig_file,
-                    filemode='w')
+#logging.basicConfig(level=logging.DEBUG,
+#                    format='%(asctime)s %(levelname)s %(message)s',
+#                    filename=LOGconfig_file,
+#                    filemode='w')
 def get_vm_list (vms,config_file):
 	try:
 		vmstring="vm_names: ["
@@ -22,10 +23,11 @@ def get_vm_list (vms,config_file):
 		vmstring +='"'+vms[-1].name+'"'+"]"
 		#print vmstring 
 		with open(config_file) as myfile:
-			out=open("config.tmp","w")
+			out=open("/tmp/config.tmp","w")
 			for line in myfile:
 				out.write(re.sub("^vm_names.*$", vmstring, line))
 			out.close()
-			os.rename("config.tmp", config_file)
+			os.rename("/tmp/config.tmp", config_file)
 	except Exception as ex:
-               logging.debug('Unexpected error: %s' % ex)
+#               logging.debug('Unexpected error getting list of vms: %s' % ex)
+		Logger.log('Unexpected error getting list of vms: %s' % ex)

--- a/vmlist.py
+++ b/vmlist.py
@@ -3,19 +3,19 @@
 import sys
 import os
 import re
-from ovirtsdk.api import API 
-from ovirtsdk.xml import params
-from threading import Thread
+#from ovirtsdk.api import API 
+#from ovirtsdk.xml import params
+#from threading import Thread
 import time
 import logging
 
 #Configure
  
-APIURL="https://engine.example.com/api/"
-APIUSER="admin@internal"
-APIPASS="securepassword:)"
-CAFILE="ca.crt"
-FILENAME="config.cfg"
+#APIURL="https://engine.example.com/api/"
+#APIUSER="admin@internal"
+#APIPASS="securepassword:)"
+#CAFILE="ca.crt"
+#FILENAME="config.cfg"
 LOGFILENAME="list_setup.log"
 
 logging.basicConfig(level=logging.DEBUG,
@@ -23,17 +23,20 @@ logging.basicConfig(level=logging.DEBUG,
                     filename=LOGFILENAME,
                     filemode='w')
 def get_vm_list (vms):
-	vmstring="vm_names: ["
-	for vm in vms[:-1]:
-		vmstring += '"'+vm.name+'"'+", " 
-	vmstring +='"'+vms[-1].name+'"'+"]"
-	#print vmstring 
-	with open(FILENAME) as myfile:
-		out=open("config.tmp","w")
-		for line in myfile:
-			out.write(re.sub("^vm_names.*$", vmstring, line))
-		out.close()
-		os.rename("config.tmp", FILENAME)
+	try:
+		vmstring="vm_names: ["
+		for vm in vms[:-1]:
+			vmstring += '"'+vm.name+'"'+", " 
+		vmstring +='"'+vms[-1].name+'"'+"]"
+		#print vmstring 
+		with open(FILENAME) as myfile:
+			out=open("config.tmp","w")
+			for line in myfile:
+				out.write(re.sub("^vm_names.*$", vmstring, line))
+			out.close()
+			os.rename("config.tmp", FILENAME)
+	except Exception as ex:
+               logging.debug('Unexpected error: %s' % ex)
 #if __name__ == "__main__":
 #   	try:	
 #        	api = API(url=APIURL,


### PR DESCRIPTION
Added flag (-a) so users can select to back up all vms. This flag prompts backup.py to run vmlist.py which get a list of all the vm's on the given system and inserts that list into the specified config file. Thus all vms will be backed up.
Currently I have vmlist using the projects loggin scheme. But I am interested why it is not simply using the already available logging (import logging) library. Is there any interest in moving to using the python logging library?