### PR TITLE
Fixed all VM's backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Set permissions to config.cfg only for the needed user (chmod 600 config.cfg).
 
 * When the ovirtsdk supports exporting a snapshot directly to a domain, the step of a VM creation can be removed to save some disk space during backup
 
-## Usefull links:
+## Useful links:
 
 * [http://www.ovirt.org/REST-Api](http://www.ovirt.org/REST-Api)
 * [http://www.ovirt.org/Python-sdk](http://www.ovirt.org/Python-sdk)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a tool, written in Python, to make **online** fullbackup's of a VM which
 
 ## Requirements
 
-It is necessery to install the oVirt Python-sdk.
+It is necessary to install the oVirt Python-sdk.
 
 [http://www.ovirt.org/Python-sdk](http://www.ovirt.org/Python-sdk)
 

--- a/backup.py
+++ b/backup.py
@@ -55,6 +55,7 @@ def main(argv):
     if all_vms:
         vms=api.vms.list(max=400)
         vmlist.get_vm_list(vms,config_file)
+        config = Config(config_file, debug)
 
     # Test if all VM names are valid
     for vm_from_list in config.get_vm_names():


### PR DESCRIPTION
Noticed in further testing that the full VM backup selection only worked on the second run with a false vm name in the config file starting out. Figured out it needed to reload the config file after inserting the updated full vm list. Config file has to be read before hand to get web/user/pass details.
Also fixed a few spelling mistakes.