### PR TITLE
Backup to template on a different storage domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,15 @@ Take a look at the example "config_example.cfg"
 ## Workflow
 
 * Create a snapshot
-* Clone the snapshot into a new VM
+* Clone the snapshot into a new VM (posibly in a different storage domain)
 * Delete the snapshot
-* Export the VM to the NFS share
+* Two differet types of backup (can use either one or both)
+  * Create a template from the cloned VM (in the same storage domain) 
+  * Export the VM to the NFS share
 * Delete the VM
+
+Backup to template can be more flexible in large instalations because you can have multiple storage domains containig backed up hosts. 
+With export based backups you can only have one export domain per datacenter
 
 ## Useful tips
 

--- a/backup.py
+++ b/backup.py
@@ -336,7 +336,7 @@ def main(argv):
 
             # Delete old backups
             VMTools.delete_old_backups(api, config, vm_from_list)
-            VMTools.delete_old_vms(api, config, vm_from_list, config.get_destination_domain())
+            VMTools.delete_old_templates(api, config, vm_from_list)
 
 	    # Create template
 	    if config.get_backup_to_template():

--- a/config.py
+++ b/config.py
@@ -42,6 +42,7 @@ class Config(object):
             self.__snapshot_description = config_parser.get(section, "snapshot_description")
             self.__cluster_name = config_parser.get(section, "cluster_name")
             self.__export_domain = config_parser.get(section, "export_domain")
+            self.__destination_domain = config_parser.get(section, "destination_domain")
             self.__timeout = config_parser.getint(section, "timeout")
             self.__backup_keep_count = config_parser.getint(section, "backup_keep_count")
             self.__dry_run = config_parser.getboolean(section, "dry_run")
@@ -49,6 +50,8 @@ class Config(object):
             self.__vm_name_max_length = config_parser.getint(section, "vm_name_max_length")
             self.__use_short_suffix = config_parser.getboolean(section, "use_short_suffix")
             self.__storage_domain = config_parser.get(section, "storage_domain")
+            self.__backup_to_template = config_parser.getboolean(section, "backup_to_template")
+            self.__backup_to_export = config_parser.getboolean(section, "backup_to_export")
             self.__storage_space_threshold = config_parser.getfloat(section, "storage_space_threshold")
             self.__logger_fmt = config_parser.get(section, "logger_fmt")
             self.__logger_file_path = config_parser.get(section, "logger_file_path")
@@ -103,6 +106,11 @@ class Config(object):
     def get_export_domain(self):
         return self.__export_domain
 
+    def get_backup_to_template(self):
+        return self.__backup_to_template
+
+    def get_backup_to_export(self):
+        return self.__backup_to_export
 
     def get_timeout(self):
         return self.__timeout
@@ -131,6 +139,8 @@ class Config(object):
     def get_storage_domain(self):
         return self.__storage_domain
 
+    def get_destination_domain(self):
+        return self.__destination_domain
 
     def get_storage_space_threshold(self):
         return self.__storage_space_threshold

--- a/config_example.cfg
+++ b/config_example.cfg
@@ -49,6 +49,15 @@ use_short_suffix=False
 # Storage domain where the VM's are located. This is important to check space usage during backup
 storage_domain=storage1
 
+# Storage domain where the cloned VMs and templates (if used) should be located (can be the same as storage_domain)
+destination_domain=backup_templates1
+
+## Type of backup (you can activate both or just one)
+# Backup to template on destination_domain
+backup_to_template=True
+# Backup to OVA on EXPORT storage domain
+backup_to_export=True
+
 # This value is used to check against the storage free space to avoid running out of space during backup.
 # Values: 0..1
 # Example: A value of 0.1 means that a free space of 10% must be available from the summarized disk size of the VM which is currently backuped up

--- a/config_example.cfg
+++ b/config_example.cfg
@@ -30,7 +30,7 @@ timeout=5
 # The name of the cluster where the VM should be cloned
 cluster_name=local_cluster
 
-# How long backups should be keeped, this is in days
+# Keep this number of backups (the most recent)
 backup_keep_count=3
 
 # If set to "True" no creation, deletion and other operations will be executed


### PR DESCRIPTION
Adds functionality to backup to templates on a different storage domain
Also, separate actions in different functions to simplify changes
Cloned VM from snapshot can be created in a different storage domain to optimize space utilization

Backups can be done to export domain (original type),  to template on a different storage domain, or both

Also, change backup retention to keep the last number of backups specified in the backup_keep_count option. Keeping  the last backups per number and not age is safer, because if we delete backups older than 3 days (for example), if backups fails for more than 3 days we will have no backups.
It's safer to keep a number of the last backups, no matter how old they are