### PR TITLE
Fix Tag Filter

### DIFF
--- a/backup.py
+++ b/backup.py
@@ -253,7 +253,7 @@ def main(argv):
             config.write_update(opts.config_file.name)
     # Add VM's with the tag to the vm list
     if opts.vm_tag:
-        vms = vms_service.list(max=400, query="tag="+opts.vm_tag)
+        vms = vms_service.list(max=400, search="tag="+opts.vm_tag)
         config.set_vm_names([vm.name for vm in vms])
         # Update config file
         if opts.config_file.name != "<stdin>":


### PR DESCRIPTION
I have this issue with the previous version when I try to use the tag : 
Traceback (most recent call last):
  File "/usr/local/bin/oVirtBackup/backup.py", line 464, in <module>
    main(sys.argv[1:])
  File "/usr/local/bin/oVirtBackup/backup.py", line 256, in main
    vms = vms_service.list(max=400, query="tag="+opts.vm_tag)
  File "/usr/lib64/python2.7/site-packages/ovirtsdk4/services.py", line 36464, in list
    query['max'] = max
TypeError: 'str' object does not support item assignment

I have just change query to search, and now it works in my case.

Regards,