### PR TITLE
fix vm.name

### DIFF
--- a/backup.py
+++ b/backup.py
@@ -7,6 +7,7 @@ import sys
 import time
 from vmtools import VMTools
 from config import Config
+import traceback
 
 """
 Main class to make the backups
@@ -432,6 +433,7 @@ def main(argv):
             vms_with_failures.remove(vm_from_list)
         except Exception as e:
             logger.error("!!! Got unexpected exception: %s", e)
+            traceback.printexc()
             api.close()
             sys.exit(1)
 

--- a/backup.py
+++ b/backup.py
@@ -433,7 +433,7 @@ def main(argv):
             vms_with_failures.remove(vm_from_list)
         except Exception as e:
             logger.error("!!! Got unexpected exception: %s", e)
-            traceback.printexc()
+            traceback.print_exc()
             api.close()
             sys.exit(1)
 

--- a/vmtools.py
+++ b/vmtools.py
@@ -122,7 +122,7 @@ class VMTools:
                         time.sleep(config.get_timeout())
                     done = True
         except Exception as e:
-            logger.info("!!! Can't delete cloned VM (%s)", vm.name)
+            logger.info("!!! Can't delete cloned VM (%s)", vm_name)
             raise e
         if done:
             logger.info("Cloned VM (%s) deleted" , vm.name)


### PR DESCRIPTION
`vm.name` does not exist if the VM is not found, leading to:

    !!! Got unexpected exception: local variable 'vm' referenced before assignment


I also added traceback to print a stack trace, otherwise the message is not very helpful.