### PR TITLE
fix backup duration per VM

### DIFF
--- a/backup.py
+++ b/backup.py
@@ -209,8 +209,6 @@ def main(argv):
         config.get_logger_fmt(), config.get_logger_file_path(), opts.debug,
     )
 
-    time_start = int(time.time())
-
     has_errors = False
 
     # Connect to server
@@ -282,6 +280,8 @@ def main(argv):
     sd_service = sds_service.list(search='name=%s' % config.get_export_domain())[0]
 
     for vm_from_list in config.get_vm_names():
+        time_start = int(time.time())
+
         config.clear_vm_suffix()
         vm_clone_name = vm_from_list + config.get_vm_middle() + config.get_vm_suffix()
 


### PR DESCRIPTION
`time_start` is defined once at the beginning of the script, so the duration displayed is not per VM. Also the time is increasing:

```
2022-01-12 22:32:38,860: Duration: 2:37 minutes
2022-01-12 22:35:58,685: Duration: 5:57 minutes
2022-01-12 22:38:46,261: Duration: 8:45 minutes
2022-01-12 22:41:08,629: Duration: 11:7 minutes
2022-01-12 22:44:16,983: Duration: 14:15 minutes
2022-01-12 22:47:10,029: Duration: 17:9 minutes
```

I simply moved the initialization of the timer inside the vm loop. Maybe we could also add a global timer?