### PR TITLE
Better portability

### DIFF
--- a/backup.py
+++ b/backup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import logging
 from argparse import ArgumentParser, FileType
 import ovirtsdk4 as sdk


### PR DESCRIPTION
/usr/bin/env is a path for env in most operating systems, while python might be installed to different places