### PR TITLE
Flags to control clone-to-vm and export-to-nfs

### DIFF
--- a/config.py
+++ b/config.py
@@ -50,6 +50,11 @@ class Config(object):
             self.__backup_keep_count = config_parser.get(section, "backup_keep_count")
             self.__backup_keep_count_by_number = config_parser.get(section, "backup_keep_count_by_number")
             self.__dry_run = config_parser.getboolean(section, "dry_run")
+            self.__clone_to_vm = config_parser.getboolean(section, "clone_to_vm")
+            self.__export_to_nfs = config_parser.getboolean(section, "export_to_nfs")
+            self.__bootable_only = config_parser.getboolean(section, "bootable_only", fallback=False)
+            self.__with_disks_deactivated = config_parser.getboolean(section, "with_disks_deactivated", fallback=False)
+            self.__disks_id_exclude = json.loads(config_parser.get(section, "disks_id_exclude", fallback="[]"))
             self.__debug = debug
             self.__vm_name_max_length = config_parser.getint(section, "vm_name_max_length")
             self.__use_short_suffix = config_parser.getboolean(section, "use_short_suffix")
@@ -125,6 +130,21 @@ class Config(object):
 
     def get_dry_run(self):
         return self.__dry_run
+
+    def get_clone_to_vm(self):
+        return self.__clone_to_vm
+
+    def get_export_to_nfs(self):
+        return self.__export_to_nfs
+
+    def get_bootable_only(self):
+        return self.__bootable_only
+
+    def get_with_disks_deactivated(self):
+        return self.__with_disks_deactivated
+
+    def get_disks_id_exclude(self):
+        return self.__disks_id_exclude
 
     def get_debug(self):
         return self.__debug


### PR DESCRIPTION
Added --clone-to-vm and --export-to-nfs options, false by default, to control if the script should create a VM clone and/or export the snapshot to the defined NFS export. These aren't always required, e.g daily backup script, so wanted them configurable.

Also includes PR #87 from GMasta2000